### PR TITLE
Fix dot indicator ui problem

### DIFF
--- a/app/src/main/java/com/oakkub/survey/ui/surveys/list/SurveysFragment.kt
+++ b/app/src/main/java/com/oakkub/survey/ui/surveys/list/SurveysFragment.kt
@@ -12,7 +12,9 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.view.doOnPreDraw
 import com.eggdigital.trueyouedc.extensions.delegateTo
+import com.eggdigital.trueyouedc.extensions.views.invisible
 import com.eggdigital.trueyouedc.extensions.views.toast
+import com.eggdigital.trueyouedc.extensions.views.visible
 import com.oakkub.survey.R
 import com.oakkub.survey.common.controller.BaseFragment
 import com.oakkub.survey.data.services.surveys.SurveyResponse
@@ -133,11 +135,13 @@ class SurveysFragment : BaseFragment() {
 
     private fun updateDotIndicatorView(totalItem: Int) {
         if (totalItem <= 1) {
+            surveysDotItemRecyclerView.invisible()
             dotIndicatorAdapter.submitList(listOf())
             return
         }
 
         view?.doOnPreDraw {
+            surveysDotItemRecyclerView.visible()
             val selectedPosition = surveysLinearLayoutManager.findFirstCompletelyVisibleItemPosition()
             val mappedResult = DotIndicatorItemMapperImpl().map(totalItem, selectedPosition)
             dotIndicatorAdapter.submitList(mappedResult)


### PR DESCRIPTION
## What happened 🤔
Vertical dot indicator when try to clear it. It will show a weird ui about a second. The way to workaround it right now is to hide it when there is no item and show it if it has.


## Insight 👀
The problem might be <a href="https://developer.android.com/reference/android/support/v7/recyclerview/extensions/ListAdapter.html">ListAdapter</a>, because it will calculate the item using diffUtil asynchronously. That's why when it calculating it might show a weird ui. Probably 🤔